### PR TITLE
Add asymmetric key init as public

### DIFF
--- a/Crypto/Sources/Data4LifeCrypto.swift
+++ b/Crypto/Sources/Data4LifeCrypto.swift
@@ -20,7 +20,9 @@ public protocol CryptorProtocol {
     static func symEncrypt(key: Key, data: Data, iv: Data) throws -> Data
     static func symDecrypt(key: Key, data: Data, iv: Data) throws -> Data
     static func asymEncrypt(key: KeyPair, data: Data) throws -> Data
+    static func asymEncrypt(publicKey: AsymmetricKey, data: Data) throws -> Data
     static func asymDecrypt(key: KeyPair, data: Data) throws -> Data
+    static func asymDecrypt(privateKey: AsymmetricKey, data: Data) throws -> Data
 }
 
 public protocol SignerProtocol {

--- a/Crypto/Sources/Model/KeyPair/AsymmetricKey/AsymmetricKey.swift
+++ b/Crypto/Sources/Model/KeyPair/AsymmetricKey/AsymmetricKey.swift
@@ -23,13 +23,15 @@ public enum AsymmetricKeyType: String {
 public struct AsymmetricKey {
     public let value: SecKey
     public let type: AsymmetricKeyType
+    public let algorithm: AlgorithmType
 
-    init(value: SecKey, type: AsymmetricKeyType ) {
+    init(value: SecKey, type: AsymmetricKeyType, algorithm: AlgorithmType) {
         self.value = value
         self.type = type
+        self.algorithm = algorithm
     }
 
-    init(data: Data, type: AsymmetricKeyType, keySize: KeySize) throws {
+    public init(data: Data, type: AsymmetricKeyType, keySize: KeySize) throws {
         var keyData = data
         let keyType = type == .private ? kSecAttrKeyClassPrivate : kSecAttrKeyClassPublic
         var error: Unmanaged<CFError>?
@@ -52,6 +54,7 @@ public struct AsymmetricKey {
 
         self.value = secKey
         self.type = type
+        self.algorithm = RSAAlgorithm()
     }
 
     public func asData() throws -> Data {

--- a/Crypto/Sources/Model/KeyPair/KeyPair+Codable.swift
+++ b/Crypto/Sources/Model/KeyPair/KeyPair+Codable.swift
@@ -59,6 +59,6 @@ extension KeyPair: Decodable {
             throw Data4LifeCryptoError.couldNotReadPublicKey
         }
 
-        self.publicKey = AsymmetricKey(value: publicKey, type: .public)
+        self.publicKey = AsymmetricKey(value: publicKey, type: .public, algorithm: algorithm)
     }
 }

--- a/Crypto/Sources/Model/KeyPair/KeyPair.swift
+++ b/Crypto/Sources/Model/KeyPair/KeyPair.swift
@@ -35,8 +35,8 @@ public struct KeyPair: KeyPairType {
     public let algorithm: AlgorithmType
 
     init(privateKey: SecKey, publicKey: SecKey, keySize: KeySize, algorithm: AlgorithmType) {
-        self.privateKey = AsymmetricKey(value: privateKey, type: .private)
-        self.publicKey = AsymmetricKey(value: publicKey, type: .public)
+        self.privateKey = AsymmetricKey(value: privateKey, type: .private, algorithm: algorithm)
+        self.publicKey = AsymmetricKey(value: publicKey, type: .public, algorithm: algorithm)
         self.keySize = keySize
         self.algorithm = algorithm
     }

--- a/Crypto/Sources/Services/Data4LifeCryptor.swift
+++ b/Crypto/Sources/Services/Data4LifeCryptor.swift
@@ -18,6 +18,7 @@ import CryptoKit
 import CommonCrypto
 
 public struct Data4LifeCryptor: CryptorProtocol {
+
     public static func symEncrypt(key: Key, data: Data, iv: Data) throws -> Data {
         return try symmetricEncrypt(key: key.value, data: data, algorithm: key.algorithm, iv: iv)
     }
@@ -32,6 +33,14 @@ public struct Data4LifeCryptor: CryptorProtocol {
 
     public static func asymDecrypt(key: KeyPair, data: Data) throws -> Data {
         return try cipher(key: key.privateKey.value, algorithm: key.algorithm).decrypt(data)
+    }
+
+    public static func asymEncrypt(publicKey: AsymmetricKey, data: Data) throws -> Data {
+        return try cipher(key: publicKey.value, algorithm: publicKey.algorithm).encrypt(data)
+    }
+
+    public static func asymDecrypt(privateKey: AsymmetricKey, data: Data) throws -> Data {
+        return try cipher(key: privateKey.value, algorithm: privateKey.algorithm).decrypt(data)
     }
 }
 

--- a/Crypto/Tests/ModelTests/AsymmetricKeyTests.swift
+++ b/Crypto/Tests/ModelTests/AsymmetricKeyTests.swift
@@ -1,0 +1,70 @@
+//  Copyright (c) 2021 D4L data4life gGmbH
+//  All rights reserved.
+//  
+//  D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+//  including any intellectual property rights that subsist in the SDK.
+//  
+//  The SDK and its documentation may be accessed and used for viewing/review purposes only.
+//  Any usage of the SDK for other purposes, including usage for the development of
+//  applications/third-party applications shall require the conclusion of a license agreement
+//  between you and D4L.
+//  
+//  If you are interested in licensing the SDK for your own applications/third-party
+//  applications and/or if you’d like to contribute to the development of the SDK, please
+//  contact D4L by email to help@data4life.care.
+
+import XCTest
+import Data4LifeCrypto
+
+class AsymmetricKeyTests: XCTestCase {
+
+    private let bundle = Foundation.Bundle.current
+
+    func testInitializeAsymmetricPrivateKeyWithDataWithSuccess() throws {
+
+        // Given
+        let size = 2048
+        let filename = "asymPrivateExchangeKeyPKCS8"
+        let keypair: KeyPair = try bundle.decodable(fromJSON: filename)
+        let asymmetricKeyData = try keypair.privateKey.asData()
+
+        // When
+        let asymmetricKey = try AsymmetricKey(data: asymmetricKeyData, type: .private, keySize: size)
+
+        // Then
+        XCTAssertNotNil(asymmetricKey)
+        XCTAssertEqual(try asymmetricKey.asBase64EncodedString(),
+                       try keypair.privateKey.asBase64EncodedString())
+
+    }
+
+    func testInitializeAsymmetricPublicKeyWithDataWithSuccess() throws {
+
+        // Given
+        let size = 2048
+        let filename = "asymPrivateExchangeKeyPKCS8"
+        let keypair: KeyPair = try bundle.decodable(fromJSON: filename)
+        let asymmetricKeyData = try keypair.publicKey.asData()
+
+        // When
+        let asymmetricKey = try AsymmetricKey(data: asymmetricKeyData, type: .public, keySize: size)
+
+        // Then
+        XCTAssertNotNil(asymmetricKey)
+        XCTAssertEqual(try asymmetricKey.asBase64EncodedString(),
+                       try keypair.publicKey.asBase64EncodedString())
+
+    }
+
+    func testInitializeAsymmetricKeyWithDataWithTypeMismatch() throws {
+
+        // Given
+        let size = 2048
+        let filename = "asymPrivateExchangeKeyPKCS8"
+        let keypair: KeyPair = try bundle.decodable(fromJSON: filename)
+        let asymmetricKeyData = try keypair.privateKey.asData()
+
+        // Then
+        XCTAssertThrowsError(try AsymmetricKey(data: asymmetricKeyData, type: .public, keySize: size))
+    }
+}

--- a/Crypto/Tests/ServiceTests/Data4LifeCryptorTests.swift
+++ b/Crypto/Tests/ServiceTests/Data4LifeCryptorTests.swift
@@ -40,6 +40,38 @@ class Data4LifeCryptoProtocolTests: XCTestCase {
         }
     }
 
+    func testAsymmetricDecryptWithAsymmetricKey() {
+        do {
+            let testModel: AsymCryptoTestModel = try bundle.decodable(fromJSON: "asymDecrypt")
+            let decryptedData = try Data4LifeCryptor.asymDecrypt(privateKey: testModel.keypair.privateKey, data: testModel.inputData)
+            XCTAssertEqual(testModel.outputData, decryptedData)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    func testAsymmetricEncryptWithAsymmetricKeyDecryptWithKeyPair() {
+        do {
+            let testModel: AsymCryptoTestModel = try bundle.decodable(fromJSON: "asymEncrypt")
+            let encryptedData = try Data4LifeCryptor.asymEncrypt(publicKey: testModel.keypair.publicKey, data: testModel.inputData)
+            let decryptedData = try Data4LifeCryptor.asymDecrypt(key: testModel.keypair, data: encryptedData)
+            XCTAssertEqual(testModel.inputData, decryptedData)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    func testAsymmetricEncryptWithAsymmetricKeyDecryptWithKey() {
+        do {
+            let testModel: AsymCryptoTestModel = try bundle.decodable(fromJSON: "asymEncrypt")
+            let encryptedData = try Data4LifeCryptor.asymEncrypt(publicKey: testModel.keypair.publicKey, data: testModel.inputData)
+            let decryptedData = try Data4LifeCryptor.asymDecrypt(privateKey: testModel.keypair.privateKey, data: encryptedData)
+            XCTAssertEqual(testModel.inputData, decryptedData)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
     func testSymmetricEncrypt() {
         do {
             let testModel: SymCryptoTestModel = try bundle.decodable(fromJSON: "symCommonEncrypt")

--- a/Data4LifeCrypto.xcodeproj/project.pbxproj
+++ b/Data4LifeCrypto.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		3661D4F826E1124700BC51F3 /* asymDonationServiceKey.json in Resources */ = {isa = PBXBuildFile; fileRef = 3661D4F726E1124700BC51F3 /* asymDonationServiceKey.json */; };
 		3661D4FD26E1226800BC51F3 /* ExampleSignature0.txt in Resources */ = {isa = PBXBuildFile; fileRef = 3661D4FC26E1226800BC51F3 /* ExampleSignature0.txt */; };
 		367B639326E238A70020C4B5 /* Data4LifeCryptoRSAPSS in Frameworks */ = {isa = PBXBuildFile; productRef = 367B639226E238A70020C4B5 /* Data4LifeCryptoRSAPSS */; };
+		36EA67DE26E900CE00A283DB /* AsymmetricKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36EA67DD26E900CE00A283DB /* AsymmetricKeyTests.swift */; };
 		36FA37D626D6667B00DDCC35 /* Data4LifeCryptoHostAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36FA37D526D6667B00DDCC35 /* Data4LifeCryptoHostAppApp.swift */; };
 		36FA37D826D6667B00DDCC35 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36FA37D726D6667B00DDCC35 /* ContentView.swift */; };
 		36FA37DA26D6667C00DDCC35 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 36FA37D926D6667C00DDCC35 /* Assets.xcassets */; };
@@ -90,6 +91,7 @@
 		3661D4F526E1118100BC51F3 /* ExampleSignature32.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = ExampleSignature32.txt; sourceTree = "<group>"; };
 		3661D4F726E1124700BC51F3 /* asymDonationServiceKey.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = asymDonationServiceKey.json; sourceTree = "<group>"; };
 		3661D4FC26E1226800BC51F3 /* ExampleSignature0.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = ExampleSignature0.txt; sourceTree = "<group>"; };
+		36EA67DD26E900CE00A283DB /* AsymmetricKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsymmetricKeyTests.swift; sourceTree = "<group>"; };
 		36FA37D326D6667B00DDCC35 /* Data4LifeCryptoHostApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Data4LifeCryptoHostApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		36FA37D526D6667B00DDCC35 /* Data4LifeCryptoHostAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Data4LifeCryptoHostAppApp.swift; sourceTree = "<group>"; };
 		36FA37D726D6667B00DDCC35 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -195,6 +197,7 @@
 			children = (
 				CD524A922260DB5C0007DB8F /* KeyPairTests.swift */,
 				3661D4C726DF7C8100BC51F3 /* KeyTests.swift */,
+				36EA67DD26E900CE00A283DB /* AsymmetricKeyTests.swift */,
 			);
 			path = ModelTests;
 			sourceTree = "<group>";
@@ -643,6 +646,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3661D4F126E10F6100BC51F3 /* Data4LifeKeyGeneratorTests.swift in Sources */,
+				36EA67DE26E900CE00A283DB /* AsymmetricKeyTests.swift in Sources */,
 				3661D4C826DF7C8100BC51F3 /* KeyTests.swift in Sources */,
 				CD1091B1225B8A0A00325389 /* KeyFactory.swift in Sources */,
 				CD1091B0225B8A0A00325389 /* Bundle+JSON.swift in Sources */,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds possibility to init an asymmetric key from data 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Data donation flow is currently needing some public keys (part of a keypair) without sharing the private one, meaning we need a way to use asymettric keys regardless of its pair, and current crypto methods dont allow that. 

Depends on #5 #6 #7 

## How is it being implemented?
<!--- Please describe in detail how you implemented your changes. -->
<!--- Include details of your implemented environment, and the tests you ran to -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the changelog accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
